### PR TITLE
Fixing missing parens in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Weather.getCurrent("Kansas City", function(current) {
 
 Weather.getForecast("Kansas City", function(forecast) {
   console.log("Forecast High in Kelvin: " + forecast.high());
-  console.log("Forecast High in Fahrenheit" + Weather.kelvinToFahrenheit( forecast.high() );
-  console.log("Forecast High in Celsius" + Weather.kelvinToCelsius( forecast.high() );
+  console.log("Forecast High in Fahrenheit" + Weather.kelvinToFahrenheit(forecast.high()));
+  console.log("Forecast High in Celsius" + Weather.kelvinToCelsius(forecast.high()));
 });
 ```
 


### PR DESCRIPTION
The example code in the README has missing parens that cause the example to error. The suggested fix fixes those errors.